### PR TITLE
Remove the disabling of luackeck 212 errors (unreferenced variable)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,5 @@ install:
   - luarocks install moses
 
 script:
-  - luacheck --std max+busted --codes src --ignore 212 213 311 611 631
+  - luacheck --std max+busted --codes src --no-self --ignore 213 311 611 631
   - busted --verbose

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Stuart is designed for embedding, and so follows some rules:
 * Class modules begin with an uppercase letter, and end up in their own file that begins with an uppercase letter (e.g. `RDD.lua`)
 * Modules begin with a lowercase letter (e.g. `stuart.lua`, `fileSystemFactory.lua`)
 * Two spaces for indents.
+* The `_` global variable is the unused variable stand-in.
 * Companion libraries such as Stuart ML (a Lua port of Spark ML) will end up in their own separate Git repo and LuaRocks module such as `"stuart-ml"`.
 
 ## Building

--- a/registerAsserts.lua
+++ b/registerAsserts.lua
@@ -26,7 +26,7 @@ local registerAsserts = function(assert)
     local collection = arguments[1]
     local key = arguments[2]
     local value = arguments[3]
-    for i, e in ipairs(collection) do
+    for _, e in ipairs(collection) do
       if e[1] == key then
         if lodashStr(e[2]) == lodashStr(value) then return true end
       end
@@ -39,7 +39,7 @@ local registerAsserts = function(assert)
   assert:register('assertion', 'contains_pair', function(state, arguments)
     local collection = arguments[1]
     local value = arguments[2]
-    for i, e in ipairs(collection) do
+    for _, e in ipairs(collection) do
       if lodashStr(e) == lodashStr(value) then return true end
     end
     return false

--- a/src/stuart/Partition.lua
+++ b/src/stuart/Partition.lua
@@ -25,7 +25,7 @@ function Partition:_flattenValues()
       x:gsub('.', function(c) t[#t+1] = c end)
       x = t
     end
-    moses.map(x, function(i, v)
+    moses.map(x, function(_, v)
       table.insert(r, {e[1], v})
     end)
     return r

--- a/src/stuart/streaming/DStream.lua
+++ b/src/stuart/streaming/DStream.lua
@@ -9,10 +9,10 @@ function DStream:initialize(ssc)
 end
 
 function DStream:_notify(validTime, rdd)
-  for i, dstream in ipairs(self.inputs) do
+  for _, dstream in ipairs(self.inputs) do
     rdd = dstream:_notify(validTime, rdd)
   end
-  for i, dstream in ipairs(self.outputs) do
+  for _, dstream in ipairs(self.outputs) do
     dstream:_notify(validTime, rdd)
   end
 end

--- a/src/stuart/streaming/HttpReceiver.lua
+++ b/src/stuart/streaming/HttpReceiver.lua
@@ -16,7 +16,7 @@ function HttpReceiver:initialize(ssc, url, mode, requestHeaders)
   self.state = 0 -- 0=receive status line, 1=receive headers, 2=receive content
 end
 
-function HttpReceiver:onHeadersReceived(headers)
+function HttpReceiver:onHeadersReceived()
 end
 
 function HttpReceiver:onStart()

--- a/src/stuart/streaming/QueueInputDStream.lua
+++ b/src/stuart/streaming/QueueInputDStream.lua
@@ -10,7 +10,7 @@ function QueueInputDStream:initialize(ssc, rdds, oneAtATime)
   self.oneAtATime = oneAtATime
 end
 
-function QueueInputDStream:compute(durationBudget)
+function QueueInputDStream:compute()
   while true do
   
     if self.oneAtATime then

--- a/src/stuart/streaming/Receiver.lua
+++ b/src/stuart/streaming/Receiver.lua
@@ -12,7 +12,7 @@ end
 function Receiver:onStop()
 end
 
-function Receiver:run(durationBudget)
+function Receiver:run()
 end
 
 return Receiver

--- a/src/stuart/streaming/StreamingContext.lua
+++ b/src/stuart/streaming/StreamingContext.lua
@@ -31,7 +31,7 @@ function StreamingContext:awaitTerminationOrTimeout(timeout)
   if not moses.isNumber(timeout) or timeout <= 0 then error('Invalid timeout') end
   
   local coroutines = {}
-  for i,dstream in ipairs(self.dstreams) do
+  for _,dstream in ipairs(self.dstreams) do
     coroutines[#coroutines+1] = {coroutine.create(dstream.compute), dstream}
   end
   
@@ -47,13 +47,13 @@ function StreamingContext:awaitTerminationOrTimeout(timeout)
     if elapsed > timeout then break end
     
     -- Run each dstream compute() function, until it yields
-    for i,copair in ipairs(coroutines) do
+    for _,copair in ipairs(coroutines) do
       local co = copair[1]
       local dstream = copair[2]
       if coroutine.status(co) == 'suspended' then
-        local ok, rdds = coroutine.resume(co, dstream, individualDStreamDurationBudget) --, now, individualDStreamDurationBudget)
+        local ok, rdds = coroutine.resume(co, dstream, individualDStreamDurationBudget)
         if ok and (rdds ~= nil) and (#rdds > 0) then
-          for j, rdd in ipairs(rdds) do dstream:_notify(now, rdd) end
+          for _, rdd in ipairs(rdds) do dstream:_notify(now, rdd) end
         end
       end
     end
@@ -69,7 +69,7 @@ end
 
 function StreamingContext:queueStream(rdds, oneAtATime)
   if not moses.isBoolean(oneAtATime) then oneAtATime = true end
-  rdds = moses.map(rdds, function(i,rdd)
+  rdds = moses.map(rdds, function(_,rdd)
     if not isInstanceOf(rdd, RDD) then rdd = self.sc:makeRDD(rdd) end
     return rdd
   end)
@@ -92,14 +92,14 @@ end
 
 function StreamingContext:start()
   if self.state == 'stopped' then error('StreamingContext has already been stopped') end
-  for i, dstream in ipairs(self.dstreams) do
+  for _, dstream in ipairs(self.dstreams) do
     dstream:start()
   end
   self.state = 'active'
 end
 
 function StreamingContext:stop()
-  for i, dstream in ipairs(self.dstreams) do
+  for _, dstream in ipairs(self.dstreams) do
     dstream:stop()
   end
   self.state = 'stopped'

--- a/src/stuart/streaming/TransformedDStream.lua
+++ b/src/stuart/streaming/TransformedDStream.lua
@@ -10,10 +10,10 @@ end
 
 function TransformedDStream:_notify(validTime, rdd)
   rdd = self.transformFunc(rdd)
-  for i, dstream in ipairs(self.inputs) do
+  for _, dstream in ipairs(self.inputs) do
     rdd = dstream:_notify(validTime, rdd)
   end
-  for i, dstream in ipairs(self.outputs) do
+  for _, dstream in ipairs(self.outputs) do
     dstream:_notify(validTime, rdd)
   end
   return rdd


### PR DESCRIPTION
Adopt use of `_` as global variable stand-in for unused vars. This is possible now that lodash has been removed from unit tests.