### PR TITLE
Rename constructor function to _init (from __init), per Microlight convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ local stuart = require 'stuart'
 
 local MyReceiver = stuart.class(Receiver)
 
-function MyReceiver:__init(ssc, hostname, port)
+function MyReceiver:_init(ssc, hostname, port)
   self:super(ssc)
   self.hostname = hostname
   self.port = port or 0

--- a/spec/stuart/RDD_takeSample_spec.lua
+++ b/spec/stuart/RDD_takeSample_spec.lua
@@ -9,7 +9,7 @@ describe('RDD', function()
   
   it('takeSample() works when RDDs contain Vector classes', function()
     local DenseVector = stuart.class()
-    function DenseVector:__init(data)
+    function DenseVector:_init(data)
       self.data = data
     end
     local vector1 = DenseVector.new({1,2,3})

--- a/spec/stuart/class_spec.lua
+++ b/spec/stuart/class_spec.lua
@@ -13,14 +13,14 @@ describe('class', function()
   
   it('constructor params work', function()
     local Giraffe = class.new()
-    function Giraffe:__init(age) self.age = age end
+    function Giraffe:_init(age) self.age = age end
     local giraffe = Giraffe.new(7)
     assert.equals(7, giraffe.age)
   end)
   
   it('class functions are accessible to instance', function()
     local Frog = class.new()
-    function Frog:__init(age) self.age = age end
+    function Frog:_init(age) self.age = age end
     function Frog:isHungry() return true end
     local frog = Frog.new(7)
     assert.equals(true, frog:isHungry())
@@ -38,12 +38,12 @@ describe('class', function()
   it('subclassing works', function()
     local Animal = class.new()
     function Animal:name() return 'generic animal' end
-    function Animal:__init(age) self.age = age end
+    function Animal:_init(age) self.age = age end
     local animal = Animal.new(7)
     assert.equals('generic animal', animal:name())
     
     local Fish = class.new(Animal)
-    function Fish:__init(age) self:super(age+1) end
+    function Fish:_init(age) self:super(age+1) end
     function Fish:name() return 'I am a fish' end
     assert.is_not_nil(Fish)
     local fish = Fish.new(9)

--- a/spec/stuart/streaming/ApacheSpark_BasicOperationsSuite_spec.lua
+++ b/spec/stuart/streaming/ApacheSpark_BasicOperationsSuite_spec.lua
@@ -11,7 +11,7 @@ registerAsserts(assert)
 
 local TestInputStream = stuart.class(DStream)
 
-function TestInputStream:__init(ctx, input, numPartitions)
+function TestInputStream:_init(ctx, input, numPartitions)
   self:super(ctx)
   self.input = input
   self.numPartitions = numPartitions

--- a/src/stuart/Context.lua
+++ b/src/stuart/Context.lua
@@ -2,7 +2,7 @@ local class = require 'stuart.class'
 
 local Context = class.new()
 
-function Context:__init(arg1, arg2, arg3, arg4)
+function Context:_init(arg1, arg2, arg3, arg4)
   local SparkConf = require 'stuart.SparkConf'
   if arg1 == nil and arg2 == nil then
     self.conf = SparkConf.new()

--- a/src/stuart/FileSystem.lua
+++ b/src/stuart/FileSystem.lua
@@ -3,7 +3,7 @@ local class = require 'stuart.class'
 -- Hadoop FileSystem adapter
 local FileSystem = class.new()
 
-function FileSystem:__init(uri)
+function FileSystem:_init(uri)
   self.uri = uri
 end
 

--- a/src/stuart/LocalFileSystem.lua
+++ b/src/stuart/LocalFileSystem.lua
@@ -3,7 +3,7 @@ local FileSystem = require 'stuart.FileSystem'
 
 local LocalFileSystem = class.new(FileSystem)
 
-function LocalFileSystem:__init(uri)
+function LocalFileSystem:_init(uri)
   self:super(uri)
 end
 

--- a/src/stuart/Partition.lua
+++ b/src/stuart/Partition.lua
@@ -2,7 +2,7 @@ local class = require 'stuart.class'
 
 local Partition = class.new()
 
-function Partition:__init(data, index)
+function Partition:_init(data, index)
   self.data = data or {}
   self.index = index or 0
 end

--- a/src/stuart/RDD.lua
+++ b/src/stuart/RDD.lua
@@ -2,7 +2,7 @@ local class = require 'stuart.class'
 
 local RDD = class.new()
 
-function RDD:__init(context, partitions)
+function RDD:_init(context, partitions)
   self.context = context
   self.id = context:getNextId()
   self.sparkContext = context

--- a/src/stuart/SparkConf.lua
+++ b/src/stuart/SparkConf.lua
@@ -2,7 +2,7 @@ local class = require 'stuart.class'
 
 local SparkConf = class.new()
 
-function SparkConf:__init()
+function SparkConf:_init()
   self.settings = {}
 end
 

--- a/src/stuart/WebHdfsFileSystem.lua
+++ b/src/stuart/WebHdfsFileSystem.lua
@@ -3,7 +3,7 @@ local FileSystem = require 'stuart.FileSystem'
 
 local WebHdfsFileSystem = class.new(FileSystem)
 
-function WebHdfsFileSystem:__init(uri)
+function WebHdfsFileSystem:_init(uri)
   local has_luasocketHttp, _ = pcall(require, 'socket.http')
   assert(has_luasocketHttp)
   self:super(uri)

--- a/src/stuart/class.lua
+++ b/src/stuart/class.lua
@@ -12,7 +12,7 @@ function M.new(base)
   if base then
     for k,v in pairs(base) do klass[k]=v end
     klass._base = base
-    base_ctor = rawget(base,'__init')
+    base_ctor = rawget(base,'_init')
   end
   klass.__index = klass
   klass._class = klass
@@ -27,9 +27,9 @@ function M.new(base)
   end
   klass.new = function(...)
     local obj = setmetatable({},klass)
-    if rawget(klass,'__init') then
+    if rawget(klass,'_init') then
       klass.super = base_ctor
-      local res = klass.__init(obj,...) -- call our constructor
+      local res = klass._init(obj,...) -- call our constructor
       if res then -- which can return a new self..
         obj = setmetatable(res,klass)
       end

--- a/src/stuart/hadoop/Path.lua
+++ b/src/stuart/hadoop/Path.lua
@@ -11,7 +11,7 @@ end
 
 local Path = class.new()
 
-function Path:__init(arg1, arg2)
+function Path:_init(arg1, arg2)
   if arg2 == nil then -- arg1=pathString
     self:_checkPathArg(arg1)
     self.uri = netUrl.parse(arg1)

--- a/src/stuart/internal/Logger.lua
+++ b/src/stuart/internal/Logger.lua
@@ -26,7 +26,7 @@ Logger.INFO = INFO
 Logger.DEBUG = DEBUG
 Logger.TRACE = TRACE
 
-function Logger:__init()
+function Logger:_init()
   self.level = INFO
 end
 

--- a/src/stuart/streaming/DStream.lua
+++ b/src/stuart/streaming/DStream.lua
@@ -2,7 +2,7 @@ local class = require 'stuart.class'
 
 local DStream = class.new()
 
-function DStream:__init(ssc)
+function DStream:_init(ssc)
   self.ssc = ssc
   self.inputs = {}
   self.outputs = {}

--- a/src/stuart/streaming/HttpReceiver.lua
+++ b/src/stuart/streaming/HttpReceiver.lua
@@ -4,7 +4,7 @@ local Receiver = require 'stuart.streaming.Receiver'
 -- Receiver capable of tailing an http chunked stream
 local HttpReceiver = class.new(Receiver)
 
-function HttpReceiver:__init(ssc, url, mode, requestHeaders)
+function HttpReceiver:_init(ssc, url, mode, requestHeaders)
   self:super(ssc)
   self.url = url
   self.mode = mode or 'text' -- 'text' or 'binary'

--- a/src/stuart/streaming/QueueInputDStream.lua
+++ b/src/stuart/streaming/QueueInputDStream.lua
@@ -3,7 +3,7 @@ local DStream = require 'stuart.streaming.DStream'
 
 local QueueInputDStream = class.new(DStream)
 
-function QueueInputDStream:__init(ssc, rdds, oneAtATime)
+function QueueInputDStream:_init(ssc, rdds, oneAtATime)
   self:super(ssc)
   self.queue = rdds
   self.oneAtATime = oneAtATime

--- a/src/stuart/streaming/Receiver.lua
+++ b/src/stuart/streaming/Receiver.lua
@@ -2,7 +2,7 @@ local class = require 'stuart.class'
 
 local Receiver = class.new()
 
-function Receiver:__init(ssc)
+function Receiver:_init(ssc)
   self.ssc = ssc
 end
 

--- a/src/stuart/streaming/ReceiverInputDStream.lua
+++ b/src/stuart/streaming/ReceiverInputDStream.lua
@@ -3,7 +3,7 @@ local DStream = require 'stuart.streaming.DStream'
 
 local ReceiverInputDStream = class.new(DStream)
 
-function ReceiverInputDStream:__init(ssc, receiver)
+function ReceiverInputDStream:_init(ssc, receiver)
   self:super(ssc)
   self.receiver = receiver
 end

--- a/src/stuart/streaming/SocketInputDStream.lua
+++ b/src/stuart/streaming/SocketInputDStream.lua
@@ -3,7 +3,7 @@ local ReceiverInputDStream = require 'stuart.streaming.ReceiverInputDStream'
 
 local SocketInputDStream = class.new(ReceiverInputDStream)
 
-function SocketInputDStream:__init(ssc, hostname, port)
+function SocketInputDStream:_init(ssc, hostname, port)
   local SocketReceiver = require 'stuart.streaming.SocketReceiver'
   local receiver = SocketReceiver.new(ssc, hostname, port)
   self:super(ssc, receiver)

--- a/src/stuart/streaming/SocketReceiver.lua
+++ b/src/stuart/streaming/SocketReceiver.lua
@@ -3,7 +3,7 @@ local Receiver = require 'stuart.streaming.Receiver'
 
 local SocketReceiver = class.new(Receiver)
 
-function SocketReceiver:__init(ssc, hostname, port)
+function SocketReceiver:_init(ssc, hostname, port)
   local has_luasocket, _ = pcall(require, 'socket')
   assert(has_luasocket)
   self:super(ssc)

--- a/src/stuart/streaming/StreamingContext.lua
+++ b/src/stuart/streaming/StreamingContext.lua
@@ -2,7 +2,7 @@ local class = require 'stuart.class'
 
 local StreamingContext = class.new()
 
-function StreamingContext:__init(sc, batchDuration)
+function StreamingContext:_init(sc, batchDuration)
   self.sc = sc
   self.sparkContext = sc
   self.batchDuration = batchDuration or 1

--- a/src/stuart/streaming/TransformedDStream.lua
+++ b/src/stuart/streaming/TransformedDStream.lua
@@ -3,7 +3,7 @@ local DStream = require 'stuart.streaming.DStream'
 
 local TransformedDStream = class.new(DStream)
 
-function TransformedDStream:__init(ssc, transformFunc)
+function TransformedDStream:_init(ssc, transformFunc)
   self:super(ssc)
   self.transformFunc = transformFunc
 end

--- a/src/stuart/streaming/WindowedDStream.lua
+++ b/src/stuart/streaming/WindowedDStream.lua
@@ -3,7 +3,7 @@ local DStream = require 'stuart.streaming.DStream'
 
 local WindowedDStream = class.new(DStream)
 
-function WindowedDStream:__init(ssc, windowDuration)
+function WindowedDStream:_init(ssc, windowDuration)
   self:super(ssc)
   self.windowDuration = windowDuration
   self.window = {}


### PR DESCRIPTION
This is better because two underscores are now reserved for Lua metamethods and no longer used anywhere by Stuart, avoiding confusion.